### PR TITLE
Fix issues with case sensitivity

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -10,6 +10,7 @@
       class="input"
       type="text"
       placeholder="Noun"
+      autocapitalize="none"
       v-model="packageName"
       v-on:keyup.13="findPackage" />
     <a class="button is-info" v-on:click="findPackage" v-if="!loading">CHECK</a>

--- a/src/app.vue
+++ b/src/app.vue
@@ -92,7 +92,7 @@ export default {
       this.$el.parentElement.querySelector('#drinkput').blur();
       this.state = 'loading';
 
-      axios.get(`https://api.npms.io/v2/package/${this.packageName}`)
+      axios.get(`https://api.npms.io/v2/package/${this.packageName}`.toLowerCase())
       .then(res => {
         this.state = 'drink';
         this.npm.title = res.data.collected.metadata.name;


### PR DESCRIPTION
Since npm no longer allows to publish packages with uppercase letters the default behavior of mobile browsers, where the leading character will be capitalized, makes most searches miss.

Best approach would be to make the search case-insensitive, but a workaround is to make at least iOS Safari and Chrome for Android skip the autocapitalization of the first character.